### PR TITLE
[tec] Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM nickblah/lua:5.1-alpine3.9
+RUN apk add ruby ruby-rdoc
+WORKDIR /app
+COPY . /app
+RUN gem install bundler:1.11.2
+RUN bundle install
+ENTRYPOINT [ "cucumber" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+## Test with Docker:
+
+If you have [Docker](https://docs.docker.com/get-docker/) installed on your machine, you can run tests without having a lua interpretter or ruby installed. Just run the following commands:
+
+Build docker image:
+
+```bash
+docker build -t forth-test .
+```
+
+Run tests:
+
+```bash
+docker run -it -v $(pwd):/app forth-test
+```


### PR DESCRIPTION
Running tests can now be done without a lua interpretter or ruby
installed on your machine. Only Docker is required.